### PR TITLE
largest-series-product: Do not test slices

### DIFF
--- a/largest-series-product/series_product.t
+++ b/largest-series-product/series_product.t
@@ -6,22 +6,15 @@ use Test::Exception;
 
 my $module = $ENV{EXERCISM} ? 'Example' : 'Series';
 
-plan tests => 13;
+plan tests => 14;
 
 ok -e "$module.pm", "Missing $module.pm"  or BAIL_OUT "You need to create file: $module.pm";
 
 eval "use $module";
 ok !$@, "Cannot load $module" or BAIL_OUT "Cannot load $module. Does it compile? Does it end with 1;?";
 can_ok $module, "new"    or BAIL_OUT "Missing package $module, or missing sub new()";
-can_ok $module, "slices" or BAIL_OUT "Missing package $module, or missing sub slices()";
 can_ok $module, "largest_product" or BAIL_OUT "Missing package $module, or missing sub largest_product()";
 
-is_deeply
-    $module->new('97867564')->slices(2),
-    [[9, 7], [7, 8], [8, 6], [6, 7], [7, 5], [5, 6], [6, 4]],
-    "test slices of two" or diag explain $module->new('97867564')->slices(2);
-
-throws_ok { $module->new('012')->slices(4) } qr/ArgumentError/, "slice length longer than digits legth throws exception";
 throws_ok { $module->new('012')->largest_product(4) } qr/ArgumentError/, "slice length longer than digits legth throws exception (largest_product)";
 
 is $module->new('0123456789')->largest_product(2), 72, "largest  product of 2";


### PR DESCRIPTION
The slices functions is an internal implementation details and thus the
test case for the largest-series-product problem should not be concerned
with testing it.

Its presence may cause students to falsely think that their solution has
to use this function, instead of the alternative implementation of only
iterating through the digits once.

The slices tests are already well-covered by the series exercise already
existing in this track.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the slices test), then consider including a
hints file and/or directory in the largest-series-product directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192
