### PR TITLE
Do not assume default values

### DIFF
--- a/sum-of-multiples/Example.pm
+++ b/sum-of-multiples/Example.pm
@@ -6,7 +6,7 @@ use List::Util 'sum';
 
 sub new {
     my ($class, @multiples_of) = @_;
-    @multiples_of = (3, 5) unless @multiples_of;
+    die "no multiples" unless scalar @multiples_of;
 
     bless { multiples_of => [@multiples_of] } => $class;
 }

--- a/sum-of-multiples/Example.pm
+++ b/sum-of-multiples/Example.pm
@@ -6,7 +6,6 @@ use List::Util 'sum';
 
 sub new {
     my ($class, @multiples_of) = @_;
-    die "no multiples" unless scalar @multiples_of;
 
     bless { multiples_of => [@multiples_of] } => $class;
 }

--- a/sum-of-multiples/sum_of_multiples.t
+++ b/sum-of-multiples/sum_of_multiples.t
@@ -5,7 +5,70 @@ use Test::More;
 
 my $module = $ENV{EXERCISM} ? 'Example' : 'SumOfMultiples';
 
-plan tests => 11;
+my @cases = (
+    {
+        factors => [3, 5],
+        limit => 1,
+        expected => 0
+    },
+    {
+        factors => [3, 5],
+        limit => 4,
+        expected => 3
+    },
+    {
+        factors => [3, 5],
+        limit => 10,
+        expected => 23
+    },
+    {
+        factors => [3, 5],
+        limit => 100,
+        expected => 2318
+    },
+    {
+        factors => [3, 5],
+        limit => 1000,
+        expected => 233168
+    },
+    {
+        factors => [7, 13, 17],
+        limit => 20,
+        expected => 51
+    },
+    {
+        factors => [4, 6],
+        limit => 15,
+        expected => 30
+    },
+    {
+        factors => [5, 6, 8],
+        limit => 150,
+        expected => 4419
+    },
+    {
+        factors => [5, 25],
+        limit => 51,
+        expected => 275
+    },
+    {
+        factors => [43, 47],
+        limit => 10000,
+        expected => 2203160
+    },
+    {
+        factors => [1],
+        limit => 100,
+        expected => 4950
+    },
+    {
+        factors => [],
+        limit => 10000,
+        expected => 0
+    }
+);
+
+plan tests => 4 + scalar @cases;
 
 ok -e "$module.pm", "Missing $module.pm"
         or BAIL_OUT "You need to create file: $module.pm";
@@ -19,10 +82,13 @@ can_ok $module, "new"
 can_ok $module, "to"
         or BAIL_OUT "Missing package $module; or missing sub to()";
 
-is $module->new(3, 5)->to(1), 0, "No multiples of 3 or 5 equals zero";
-is $module->new(3, 5)->to(4), 3, "One multiple of 3";
-is $module->new(3, 5)->to(10), 23, "Multiples of 3 and 5";
-is $module->new(3, 5)->to(100), 2_318, "Multiples of 3 and 5 to 100";
-is $module->new(3, 5)->to(1000), 233_168, "A lot of multiples of 3 and 5";
-is $module->new(7, 13, 17)->to(20), 51, "Multiples of 7, 13, 17";
-is $module->new(43, 47)->to(10_000), 2_203_160, "Multiples of 43, 47";
+
+for my $case (@cases) {
+    my @factors = @{$case->{factors}};
+	my $desc = sprintf "Multiples of %s up to %s equals %s",
+					   (scalar @factors ? (join ' and ', @factors) : 'nothing'),
+				       $case->{limit}, $case->{expected};
+
+    is $module->new(@factors)->to($case->{limit}), $case->{expected}, $desc;
+}
+

--- a/sum-of-multiples/sum_of_multiples.t
+++ b/sum-of-multiples/sum_of_multiples.t
@@ -19,10 +19,10 @@ can_ok $module, "new"
 can_ok $module, "to"
         or BAIL_OUT "Missing package $module; or missing sub to()";
 
-is $module->new->to(1), 0, "No multiples of 3 or 5 equals zero";
-is $module->new->to(4), 3, "One multiple of 3";
-is $module->new->to(10), 23, "Multiples of 3 and 5";
-is $module->new->to(100), 2_318, "Multiples of 3 and 5 to 100";
-is $module->new->to(1000), 233_168, "A lot of multiples of 3 and 5";
+is $module->new(3, 5)->to(1), 0, "No multiples of 3 or 5 equals zero";
+is $module->new(3, 5)->to(4), 3, "One multiple of 3";
+is $module->new(3, 5)->to(10), 23, "Multiples of 3 and 5";
+is $module->new(3, 5)->to(100), 2_318, "Multiples of 3 and 5 to 100";
+is $module->new(3, 5)->to(1000), 233_168, "A lot of multiples of 3 and 5";
 is $module->new(7, 13, 17)->to(20), 51, "Multiples of 7, 13, 17";
 is $module->new(43, 47)->to(10_000), 2_203_160, "Multiples of 43, 47";

--- a/sum-of-multiples/sum_of_multiples.t
+++ b/sum-of-multiples/sum_of_multiples.t
@@ -85,9 +85,9 @@ can_ok $module, "to"
 
 for my $case (@cases) {
     my @factors = @{$case->{factors}};
-	my $desc = sprintf "Multiples of %s up to %s equals %s",
-					   (scalar @factors ? (join ' and ', @factors) : 'nothing'),
-				       $case->{limit}, $case->{expected};
+    my $desc = sprintf "Multiples of %s up to %s equals %s",
+                       (scalar @factors ? (join ' and ', @factors) : 'nothing'),
+                       $case->{limit}, $case->{expected};
 
     is $module->new(@factors)->to($case->{limit}), $case->{expected}, $desc;
 }


### PR DESCRIPTION
Fixes #110

This removes the assumption that the multiples default to 3 and 5 if not provided.