### PR TITLE
add the attribution for the icon that the Perl foundation let us use

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 The MIT License (MIT)
 
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+
+### Perl 5 icon
+The onion is the logo of the Perl Foundation.
+It is trademarked, and we have adapted it--changing the color--with their permission.
+The Perl Foundation does not support or endorse Exercism.


### PR DESCRIPTION
Copied from exercism.io's ATTRIBUTION.md so it's here when the files that file refers to go away.

a step in fixing https://github.com/exercism/exercism.io/issues/3112.