### PR TITLE
Remove license info from README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+Copyright (c) 2017 Exercism, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We don't need the duplication, especially now that the GitHub interface shows the
license information on the main page of the repository when it can be detected
directly from the LICENSE file.

This also updates the license file to reassign copyright to the Exercism legal entity.