### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 sudo: false
 language: perl
 perl:
+  - '5.26'
+  - '5.24'
   - '5.22'
   - '5.20'
   - '5.18'
   - '5.16'
   - '5.14'
   - '5.12'
-  - '5.10'
 before_script:
   - bin/fetch-configlet
 script:
   - bin/configlet .
-  - EXERCISM=1 prove -vr exercises/
+  - prove -r exercises/


### PR DESCRIPTION
1. 5.10 doesn't let you put the module version number in the package declaration. Since 5.12 came out over 7 years ago, I don't think dropping 5.10 would be the end of the world. (You can use `our $VERSION` for 5.10, but I didn't really want to do that just for the sake of 5.10).

2. 5.24 and 5.26 have been released since this was last updated.

3. The `EXERCISM` env var is now in travis and does not need to be part of the `prove` command.