### PR TITLE
Add Path::Tiny to cpanfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The tests depend on the following modules:
     DateTime
     Test::Exception
     List::MoreUtils
+    Path::Tiny (for canonical-data tests)
 
 ## Testing the Tests
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
-requires 'JSON', 0;
-requires 'DateTime', 0;
-requires 'Test::Exception', 0;
-requires 'List::MoreUtils', 0;
+requires 'JSON';
+requires 'DateTime';
+requires 'Test::Exception';
+requires 'List::MoreUtils';
+requires 'Path::Tiny';


### PR DESCRIPTION
Path::Tiny will be needed for travis to successfully run canonical data tests from the generator.